### PR TITLE
Fix influx client by formatting connection url

### DIFF
--- a/grottconf.py
+++ b/grottconf.py
@@ -152,7 +152,7 @@ class Conf :
                     raise SystemExit("Grott Influxdb initialisation error")
 
                 #self.influxclient = InfluxDBClient(url='192.168.0.211:8086',org=self.iforg, token=self.iftoken)
-                self.influxclient = InfluxDBClient(url=self.ifip + ":" + self.ifport,org=self.iforg, token=self.iftoken)
+                self.influxclient = InfluxDBClient(url="{}:{}".format(self.ifip, self.ifport),org=self.iforg, token=self.iftoken)
                 self.ifbucket_api = self.influxclient.buckets_api()
                 self.iforganization_api = self.influxclient.organizations_api()              
                 self.ifwrite_api = self.influxclient.write_api(write_options=SYNCHRONOUS)


### PR DESCRIPTION
Format the connection url to merge the string ip and integer port in one string. Currently the concatenation fails as the port is not a string