### PR TITLE
Add an inverter serial <-> inverter type map

### DIFF
--- a/grottconf.py
+++ b/grottconf.py
@@ -21,6 +21,7 @@ class Conf :
         self.decrypt = True
         self.compat = False
         self.invtype = "default"                                                                    #specify sepcial invertype default (spf, sph)
+        self.invtypemap = {}
         self.includeall = False                                                                      #Include all defined keys from layout (also incl = no)
         self.blockcmd = False                                                                       #Block Inverter and Shine configure commands                
         self.noipf = False                                                                          #Allow IP change if needed
@@ -200,6 +201,7 @@ class Conf :
         print("\tdecrypt:             \t",self.decrypt)
         print("\tcompat:              \t",self.compat)
         print("\tinvtype:             \t",self.invtype)
+        print("\tinvtypemap:          \t",self.invtypemap)
         print("\tinclude_all:         \t",self.includeall)
         print("\tblockcmd:            \t",self.blockcmd)
         print("\tnoipf:               \t",self.noipf)
@@ -360,6 +362,7 @@ class Conf :
         if config.has_option("Generic","compat"): self.compat = config.getboolean("Generic","compat")
         if config.has_option("Generic","includeall"): self.includeall = config.getboolean("Generic","includeall")
         if config.has_option("Generic","invtype"): self.invtype = config.get("Generic","invtype")
+        if config.has_option("Generic","invtypemap"): self.invtypemap = eval(config.get("Generic","invtypemap"))
         if config.has_option("Generic","inverterid"): self.inverterid = config.get("Generic","inverterid")
         if config.has_option("Generic","blockcmd"): self.blockcmd = config.get("Generic","blockcmd")
         if config.has_option("Generic","noipf"): self.noipf = config.get("Generic","noipf")
@@ -427,6 +430,7 @@ class Conf :
         if os.getenv('gcompat') != None :  self.compat = self.getenv('gcompat')
         if os.getenv('gincludeall') != None :  self.includeall = self.getenv('gincludeall')
         if os.getenv('ginvtype') != None :  self.invtype = self.getenv('ginvtype')
+        if os.getenv('ginvtypemap') != None :  self.invtypemap = eval(self.getenv('ginvtypemap'))
         if os.getenv('gblockcmd') != None : self.blockcmd = self.getenv('gblockcmd')
         if os.getenv('gnoipf') != None : self.noipf = self.getenv('gnoipf')
         if os.getenv('gtime') in ("auto", "server") : self.gtime = self.getenv('gtime')

--- a/grottdata.py
+++ b/grottdata.py
@@ -143,6 +143,28 @@ def procdata(conf,data):
     if conf.compat is False: 
         # new method if compat = False (automatic detection):  
        
+        if (conf.invtype == "default") :
+            # Handle systems with mixed invtype
+            if (ndata > 50) :
+                # There is enough data for an inverter serial number
+                inverterType = "default"
+
+                inverterSerial = result_string[76:96]
+                inverterSerial = codecs.decode(inverterSerial, "hex").decode('utf-8')
+                if conf.verbose:
+                    print("\t - Possible Inverter serial", inverterSerial)
+
+                # Lookup inverter type based on inverter serial
+                try:
+                    inverterType = conf.invtypemap[inverterSerial]
+                    print("\t - Matched inverter serial to inverter type", inverterType)
+                except:
+                    inverterType = "default"
+                    print("\t - Inverter serial not recognised - using inverter type", inverterType)
+
+                if (inverterType != "default") :
+                    layout = layout + inverterType.upper()
+
         if conf.verbose: 
            print("\t - " + 'Growatt new layout processing')
            print("\t\t - " + "decrypt       : ",conf.decrypt)
@@ -632,4 +654,4 @@ def procdata(conf,data):
             ##print("\t -", ext_result)
     else: 
             if conf.verbose : print("\t - " + "Grott extension processing disabled ")      
-            
+


### PR DESCRIPTION
I have installation with two inverters. One is a hybrid inverter, one is standard. To extract all of the relevant data, the messages need to be processed based on inverter type. The solution I came up with was to add support for mapping data logger serial numbers to inverter types. This PR implements that solution.

I only have my own system to test with and very limited data on expected message formats etc. so I would not be surprised if things needed to be changed to be more generally useful.

If there is interest in merging this PR, I'd be happy to make any necessary adjustments so that can happen.