### PR TITLE
Do not run the Grott service as root

### DIFF
--- a/grott.service
+++ b/grott.service
@@ -8,7 +8,7 @@ After=network.target
 [Service]
 SyslogIdentifier=grott
 Type=simple
-User=root
+User=pi
 
 WorkingDirectory=/home/pi/grott/
 ExecStart=-/usr/bin/python3 -u /home/pi/grott/grott.py -v


### PR DESCRIPTION
In proxy-mode, no root access is needed