### PR TITLE
Do not run as root

### DIFF
--- a/grott.service
+++ b/grott.service
@@ -8,7 +8,7 @@ After=network.target
 [Service]
 SyslogIdentifier=grott
 Type=simple
-User=root
+User=pi
 
 WorkingDirectory=/home/pi/grott/
 ExecStart=-/usr/bin/python3 -u /home/pi/grott/grott.py -v


### PR DESCRIPTION
If in proxy mode, it's not necessary to run as root. Running as pi is safer. It would be better to create a dedicated user (and home directory) for the service during install