### PR TITLE
Add DNS resolution for growatt server address

### DIFF
--- a/grottconf.py
+++ b/grottconf.py
@@ -36,7 +36,7 @@ class Conf :
         self.tmzone = "local"                                                                       #set timezone (at this moment only used for influxdb)                
 
         #Growatt server default 
-        self.growattip = "47.91.67.66"
+        self.growattip = "server.growatt.com"
         self.growattport = 5279
 
         #MQTT default

--- a/grottproxy.py
+++ b/grottproxy.py
@@ -119,6 +119,12 @@ class Proxy:
             print("IP and port information not available") 
 
         self.server.listen(200)
+        try:
+            conf.growattip = socket.gethostbyname(conf.growattip)
+            if conf.verbose:
+                print(f"Resolved server ip: {conf.growattip}")
+        except socket.gaierror:
+            print("Error while resolving growatt server address")
         self.forward_to = (conf.growattip, conf.growattport)
         
     def main(self,conf):


### PR DESCRIPTION
A small patch, which allow to dynamically query the IP of the server.

It resolves by default `server.growatt.com`, so if one day they change their ip, it will self reconfigure (still need to stop and restart the server).

If an IP is put in the config, it won't change the behaviour.