### PR TITLE
Doc tool [update 2] - Attempt to handle all inverter types

### DIFF
--- a/examples/grottregcheck.py
+++ b/examples/grottregcheck.py
@@ -125,7 +125,8 @@ class GrottRegChecker:
             if ascii_to:
                 ascii_to = self._translate_reg_to_pos(ascii_to)
                 ascii_to += self.second_group_offset
-            if self.inverter == InverterType.SPF and x >= 90 and self.has_third_map:
+            if self.inverter == InverterType.SPF and x >= 90 and self.has_third_map or \
+                    self.inverter == InverterType.SPA and x >= 250 and self.has_third_map:
                 """ Apply the offset once more to move behind the third
                     register map
                 """


### PR DESCRIPTION
Should handle cases where there are 3 register maps in the packet (as discussed in #222). This applies to SPF and SPA inverters for now.
For the report packets (03) from MIX / SPA / SPH, the inverter property will be set to SPH if the packet has 2 register maps in it.

