### PR TITLE
Doctoll

### DIFF
--- a/examples/grottregcheck.py
+++ b/examples/grottregcheck.py
@@ -125,7 +125,8 @@ class GrottRegChecker:
             if ascii_to:
                 ascii_to = self._translate_reg_to_pos(ascii_to)
                 ascii_to += self.second_group_offset
-            if self.inverter == InverterType.SPF and x >= 90 and self.has_third_map:
+            if self.inverter == InverterType.SPF and x >= 90 and self.has_third_map or \
+                    self.inverter == InverterType.SPA and x >= 250 and self.has_third_map:
                 """ Apply the offset once more to move behind the third
                     register map
                 """

--- a/examples/grottregcheck.py
+++ b/examples/grottregcheck.py
@@ -1,5 +1,32 @@
 # coding: utf-8
 import enum
+from typing import List
+import struct
+
+
+__DEBUG__ = False
+
+
+class GrottDataMarker:
+    """
+    The data marker specifies the position in the packet
+    where the registers <from_reg> <to_reg> are located
+    """
+    def __init__(self, pos, start, end):
+        self.data_from = pos
+        self.from_reg = start
+        self.to_reg = end
+
+    def __repr__(self):
+        return f'<Marker @ [{self.data_from-8}-{self.data_from}]> reg: [{self.from_reg}:{self.to_reg}]'
+
+
+class GrottConstants:
+
+    MASK = b'Growatt'  # Encryption mask
+    HEADER_PLAIN = 8  # Unencrypted
+    HEADER_MAX_LEN = 158  # for packet in HEX format
+    PACKET_CRC = -2  # Last 2 bytes
 
 
 class InverterType(str, enum.Enum):
@@ -18,6 +45,11 @@ class InverterType(str, enum.Enum):
         return InverterType.UNKNOWN
 
 
+class InvalidRegister(Exception):
+    """ Raised on invalid/unknow register ID """
+    pass
+
+
 class GrottRegChecker:
     """ 
     Performs register checks as they are described in the
@@ -34,9 +66,9 @@ class GrottRegChecker:
     Examples:
     >>> checker = GrottRegChecker('''...''')
     >>> checker.ascii_at(125, 132)
-    {"value" :666, "length" : 14, "type" : "text"},
+    {"value" :666, "length" : 16, "type" : "text"},
     'PV   80000    '
-    >>> checker.ascii_at(34, 42)
+    >>> checker.ascii_at(34, 41)
     {"value" :294, "length" : 16, "type" : "text"},
     '   PV Inverter  '
     >>> checker.int_at(45)
@@ -49,8 +81,6 @@ class GrottRegChecker:
     
     """
 
-    header_max_len = 158
-    """ MAX header length. Scan this range for a register map """
     second_group_offset = 2
     
     def __init__(self, hex_data: str):
@@ -61,9 +91,10 @@ class GrottRegChecker:
         self.packet = ''.join([x.strip() for x in hex_data.split('\n')])
         self.debug = False
         self.verbose = False
-        self.apply_2b_offset = True  # Enabled by default
         self.data_start = 0
         self.inverter = self.inv_auto_detect()
+        if self.inverter != InverterType.UNKNOWN:
+            self.regmaps = self.map_extractor()
 
     def int_at(self, register: int):
         """ Try to extract an integer from the provided position """
@@ -82,9 +113,7 @@ class GrottRegChecker:
             start and end registers.
 
         :param s_register: Start of the ASCII string
-        :param e_register: End register of the string. 
-            Note: This should be the number at the start of the next row 
-            after the ASCII definition in the documentation
+        :param e_register: End register of the string.
         """
         start, end = self._reg_boundary(s_register, ascii_to=e_register)
         try:
@@ -114,41 +143,22 @@ class GrottRegChecker:
             Transform the ID to start/end positions in the plain
             data
         """
-        second_group = 44 if self.inverter == InverterType.SPF else 124
         x = self._translate_reg_to_pos(x)
 
-        if self.apply_2b_offset and x > second_group:
-            """ Always use 2 bytes offset  
-                if the register is in the second group
-            """
-            x += self.second_group_offset
-            if ascii_to:
-                ascii_to = self._translate_reg_to_pos(ascii_to)
-                ascii_to += self.second_group_offset
-            if self.inverter == InverterType.SPF and x >= 90 and self.has_third_map or \
-                    self.inverter == InverterType.SPA and x >= 250 and self.has_third_map:
-                """ Apply the offset once more to move behind the third
-                    register map
-                """
-                x += self.second_group_offset
-                if ascii_to:
-                    ascii_to += self.second_group_offset
-
         if ascii_to:
-            x_end = ascii_to * 2
-            x = x * 2
+            x_end = self._translate_reg_to_pos(ascii_to) + 4
             if self.debug:
-                print(f'[{self.data_start + x*2}:{self.data_start + x_end * 2}]')
-            return self.data_start + x*2, self.data_start + x_end*2
+                print(f'ASCII end at: {x_end}')
         else:
-            x = x * 2
             if long:
-                x_end = x + 4
+                x_end = x + 8
             else:
-                x_end = x + 2
+                x_end = x + 4
+            if self.debug:
+                print(f'Int/Long end at: {x_end}')
         if self.debug:
-            print(f'[{self.data_start + x * 2}:{self.data_start + x_end * 2}]')
-        return self.data_start + x * 2, self.data_start + x_end * 2
+            print(f'[{x}:{x_end}]')
+        return x, x_end
     
     @property
     def report(self) -> bool:
@@ -175,13 +185,39 @@ class GrottRegChecker:
             Update the data_start property if the string is found
         """
         try:
-            position = self.packet[:self.header_max_len].index(hex_str)
+            position = self.packet[:GrottConstants.HEADER_MAX_LEN].index(hex_str)
             self.data_start = position + 10
             return True
         except ValueError:
             return False
         except Exception as e:
             print(e)
+
+    def map_extractor(self) -> List[GrottDataMarker]:
+        """
+        Extract the register maps from the packet
+        """
+
+        marker = self.data_start - 10
+        reg_s, reg_e = struct.unpack('>hh', bytes.fromhex(self.packet[marker + 2:marker + 10]))
+        num_registers = reg_e - reg_s + 1
+        regs = [GrottDataMarker(marker + 10, reg_s, reg_e)]
+        data_start = marker + 10
+
+        while True:
+            marker_next = num_registers * 4 + data_start
+            if marker_next + 8 > len(self.packet):
+                break
+            if __DEBUG__:
+                print(f'Searching for next map @ {marker_next}')
+            reg_s, reg_e = struct.unpack('>hh', bytes.fromhex(self.packet[marker_next:marker_next + 8]))
+            """ Mapping for the start:end register in this section """
+            if reg_e > reg_s:
+                regs.append(GrottDataMarker(marker_next + 8, reg_s, reg_e))
+            data_start = marker_next + 8
+            num_registers = reg_e - reg_s + 1
+
+        return regs
 
     def inv_auto_detect(self) -> InverterType:
         """
@@ -213,7 +249,12 @@ class GrottRegChecker:
                         Return SPH for now 
                     """
                     # TODO: Find the difference between SPH & MIX
+                    # If needed. The mapping is identical anyway
                     return InverterType.SPH
+            if self._in_header('030000007c'):
+                """ Definitely SPH. Thanks @"""
+                return InverterType.SPH
+
         if self.report:
             if self._in_header('020000002c') or self._in_header('030000002c'):
                 return InverterType.SPF
@@ -230,57 +271,28 @@ class GrottRegChecker:
                 elif self.packet[next_map:next_map+8] == '03e80464':
                     """ Need more info about the storage type inverters 
                         and their report (03) packet
-                        MIX / SPA / SPH all use the [1000:1024] range 
+                        MIX / SPA / SPH all use the [1000:1124] range 
                     """
-                    # TODO: Find a way to distinguish between these types
-                    if self.has_third_map:
-                        return InverterType.SPA
+                    # TODO: Find a way to distinguish between these types if needed
+                    # As the packet contains the same data for these registers this seems unnecessary
                     return InverterType.SPH
+            elif self._in_header('030000007c'):
+                return InverterType.SPH
+
         return inv_default
 
     def _translate_reg_to_pos(self, reg: int):
         """
-        Translate a register to position
-        Used by the _reg_boundary method to map a register to its
-        actual position in the packet
+        Translate a register to position.
+
+        Uses the new data markers. Much cleaner and accurate code
         """
-        """ Directly mapped """
-        if self.inverter in [InverterType.MAX, InverterType.MID, InverterType.MAC]:
-            return reg
-        if self.inverter == InverterType.SPF:
-            return reg
 
-        """ Inverters which registers need translation """
-        if self.inverter == InverterType.MIN:
-            if self.report and reg <= 124:
-                return reg
-            elif self.report and reg >= 3000:
-                return 125 + reg - 3000
-            if self.datapacket or self.buffered:
-                return reg - 3000
+        for _map in self.regmaps:
+            if _map.from_reg <= reg <= _map.to_reg:
+                reg_idx = [x for x in range(_map.from_reg, _map.to_reg + 1)].index(reg)
+                if __DEBUG__:
+                    print(f'GrottDataMarker pos: {_map.data_from + reg_idx * 4}')
+                return _map.data_from + reg_idx * 4
 
-        if self.inverter in [InverterType.MIX, InverterType.SPA, InverterType.SPH]:
-            if self.report:
-                if reg <= 124:
-                    return reg
-                else:
-                    return 125 + reg - 1000
-            if self.datapacket or self.buffered:
-                if self.inverter in [InverterType.MIX, InverterType.SPH]:
-                    if reg <= 124:
-                        return reg
-                    else:
-                        return 125 + reg - 1000
-                elif self.inverter == InverterType.SPA:
-                    if 1000 < reg <= 1124:
-                        return reg - 1000
-                    elif 1130 < reg <= 1140:
-                        """ These should be at the end pf the packet 
-                            Pure speculation at the moment (needs a real packet from SPA for verification)
-                        """
-                        return 250 + reg - 1130
-                    else:
-                        return 125 + reg - 2000
-
-        # Raise error in case that we have unhandled case
-        raise ValueError(f'Unhandled inverter/register combination {self.inverter} -> {reg}')
+        raise InvalidRegister(f'This packet has no register with ID <{reg}>')


### PR DESCRIPTION
* Auto register map. All registers which the packet contains should be recognized automatically (will be exposed as a list of GrottDataMarker objects in the regmaps attribute)
* Auto translation. Register (index is the same as in the documentation) provided to the int_to, long_to, ascii_to methods will fetch the value for the respective register in the packet. Raises InvalidRegister error if the packet does not contain data for this register.
* Should recognize all type of packets.
* Tested with all packets which have been found and provided (thanks @egguy)