### PR TITLE
Split sensors.yaml into mqtt.yaml and template.yaml to match new HA c…

### DIFF
--- a/examples/Home Assistent/mqtt_growatt_eng.yaml
+++ b/examples/Home Assistent/mqtt_growatt_eng.yaml
@@ -3,42 +3,13 @@
 # This file exposes all sensors from Grott to HA, including dummy sensors for the type of the inverter and the type and serial number of the datalogger (Be aware, the dummy
 # sensors have to be set manually) 
 
-- platform: template
-  sensors:
-    growatt_inverter:
-      unique_id: growatt_invertertype
-      friendly_name: Growatt - Type
-      # Please set the type of your inverter
-      value_template: "MIN 4200TL-XE"
-      icon_template: mdi:select-inverse
-
-- platform: template
-  sensors:
-    growatt_datalogger_type:
-      unique_id: growatt_datloggertype
-      friendly_name: Growatt - Datalogger type
-      # Please set the type of your datalogger
-      value_template: "ShineLink X"
-      icon_template: mdi:select-inverse
-
-- platform: template
-  sensors:
-    growatt_datalogger_serial:
-      unique_id: growatt_datlogger_serial
-      friendly_name: Growatt - Datalogger serienr
-      # Please set the serial number of your datalogger
-      value_template: "	XXX1X23456"
-      icon_template: mdi:select-inverse
-
-- platform: mqtt
+- name: Growatt - Serial number
   state_topic: energy/growatt
   value_template: "{{ value_json['device'] }}" 
   unique_id: growatt_serial
-  name: Growatt - Serial number
   icon: mdi:select-inverse
 
-- platform: mqtt
-  state_topic: energy/growatt
+- state_topic: energy/growatt
   # If you like to have the date in another format, please change "timestamp_custom('%d-%m-%Y')"
   # For more information: https://docs.python.org/3/library/time.html#time.strftime
   value_template: "{{ as_timestamp(strptime(value_json['time'], '%Y-%m-%dT%H:%M:%S')) | timestamp_custom('%d-%m-%Y') }}" 
@@ -46,8 +17,7 @@
   name: Growatt - Date
   icon: mdi:calendar
 
-- platform: mqtt
-  state_topic: energy/growatt
+- state_topic: energy/growatt
   # If you like to have the date in another format, please change "timestamp_custom('%H:%M:%S')"
   # For more information: https://docs.python.org/3/library/time.html#time.strftime
   value_template: "{{ as_timestamp(strptime(value_json['time'], '%Y-%m-%dT%H:%M:%S')) | timestamp_custom('%H:%M:%S') }}" 
@@ -55,8 +25,7 @@
   name: Growatt - Time
   icon: mdi:clock-digital
 
-- platform: mqtt
-  state_topic: energy/growatt
+- state_topic: energy/growatt
   value_template: >
     {% if (value_json['values']['pvstatus'] | int == 0) %}
       Waiting
@@ -71,88 +40,77 @@
   name: Growatt - State
   icon: mdi:power-settings
 
-- platform: mqtt
-  state_topic: energy/growatt
+- state_topic: energy/growatt
   value_template: "{{ value_json['values']['pv1watt'] | float / 10000 }}"
   unique_id: growatt_string1_watt
   device_class: power
   unit_of_measurement: "kW"
   name: Growatt - String 1 (kiloWatt)
 
-- platform: mqtt
-  state_topic: energy/growatt
+- state_topic: energy/growatt
   value_template: "{{ value_json['values']['pv1voltage'] | float / 10 }}"
   unique_id: growatt_string1_voltage
   device_class: voltage
   unit_of_measurement: "V"
   name: Growatt - String 1 (Voltage)
 
-- platform: mqtt
-  state_topic: energy/growatt
+- state_topic: energy/growatt
   value_template: "{{ value_json['values']['pv1current'] | float / 10 }}"
   unique_id: growatt_string1_current
   device_class: current
   unit_of_measurement: "A"
   name: Growatt - String 1 (Current)
 
-- platform: mqtt
-  state_topic: energy/growatt
+- state_topic: energy/growatt
   value_template: "{{ value_json['values']['pv2watt'] | float / 10000 }}"
   unique_id: growatt_string2_watt
   device_class: power
   unit_of_measurement: "kW"
   name: Growatt - String 2 (kiloWatt)
 
-- platform: mqtt
-  state_topic: energy/growatt
+- state_topic: energy/growatt
   value_template: "{{ value_json['values']['pv2voltage'] | float / 10 }}"
   unique_id: growatt_string2_voltage
   device_class: voltage
   unit_of_measurement: "V"
   name: Growatt - String 2 (Voltage)
 
-- platform: mqtt
-  state_topic: energy/growatt
+- state_topic: energy/growatt
   value_template: "{{ value_json['values']['pv2current'] | float / 10 }}"
   unique_id: growatt_string2_current
   device_class: current
   unit_of_measurement: "A"
   name: Growatt - String 2 (Current)
 
-- platform: mqtt
-  state_topic: energy/growatt
+- state_topic: energy/growatt
   value_template: "{{ value_json['values']['pvpowerin'] | float / 10000 }}"
   unique_id: growatt_actual_input_power
   device_class: power
   unit_of_measurement: "kW"
   name: Growatt - Input kiloWatt (Actual)
 
-- platform: mqtt
-  state_topic: energy/growatt
+- state_topic: energy/growatt
   value_template: "{{ value_json['values']['pvpowerout'] | float / 10000 }}"
   unique_id: growatt_actual_output_power
   device_class: power
   unit_of_measurement: "kW"
   name: Growatt - Output kiloWatt (Actual)
 
-- platform: mqtt
-  state_topic: energy/growatt
+- state_topic: energy/growatt
   value_template: "{{ value_json['values']['pvfrequentie'] | float / 100 }}"
   unique_id: growatt_grid_frequency
   unit_of_measurement: "Hz"
   name: Growatt - Grid frequency
   icon: mdi:waveform
 
-- platform: mqtt
-  state_topic: energy/growatt
+- state_topic: energy/growatt
   value_template: "{{ value_json['values']['pvgridvoltage'] | float / 10 }}"
   unique_id: growatt_phase_voltage
   device_class: voltage
   unit_of_measurement: "V"
   name: Growatt - Phase voltage
 
-- platform: mqtt
-  state_topic: energy/growatt
+- state_topic: energy/growatt
   value_template: "{{ value_json['values']['pvenergytoday'] | float / 10 }}"
   unique_id: growatt_generated_energy_today
   device_class: energy
@@ -160,8 +118,7 @@
   name: Growatt - Generated energy (Today)
   icon: mdi:solar-power
 
-- platform: mqtt
-  state_topic: energy/growatt
+- state_topic: energy/growatt
   value_template: "{{ value_json['values']['pvenergytotal'] | float / 10 }}"
   unique_id: growatt_generated_energy_total
   device_class: energy
@@ -170,8 +127,7 @@
   name: Growatt - Generated energy (Total)
   icon: mdi:solar-power
 
-- platform: mqtt
-  state_topic: energy/growatt
+- state_topic: energy/growatt
   value_template: "{{ value_json['values']['pvtemperature'] | float / 10 }}"
   unique_id: growatt_inverer_temperature
   device_class: temperature
@@ -180,8 +136,7 @@
 
 # The entity below is not available in all inverters.
 
-- platform: mqtt
-  state_topic: energy/growatt
+- state_topic: energy/growatt
   value_template: "{{ value_json['values']['pvipmtemperature'] | float / 10 }}"
   unique_id: growatt_ipm_temperature
   device_class: temperature

--- a/examples/Home Assistent/template_growatt_eng.yaml
+++ b/examples/Home Assistent/template_growatt_eng.yaml
@@ -1,0 +1,22 @@
+# Grott - Home Assistant Growatt sensors 
+# 
+# This file exposes all sensors from Grott to HA, including dummy sensors for the type of the inverter and the type and serial number of the datalogger (Be aware, the dummy
+# sensors have to be set manually) 
+
+- name: Growatt - Type
+  unique_id: growatt_invertertype
+  # Please set the type of your inverter
+  state: "SPH6000"
+  icon: mdi:select-inverse
+
+- name: Growatt - Datalogger type
+  unique_id: growatt_datloggertype
+  # Please set the type of your datalogger
+  state: "ShineWifi S"
+  icon: mdi:select-inverse
+
+- name: Growatt - Datalogger serial
+  unique_id: growatt_datlogger_serial
+  # Please set the serial number of your datalogger
+  state: "ABCDEFG"
+  icon: mdi:select-inverse


### PR DESCRIPTION
I'm new to home assistant (as in less than a week using HA, and less than a day trying to use grott) so hopefully this is more helpful than noise.

Trying to set up grott and started with the example templates for Home Assitant, but I got notifications from mqtt that the sensors are in the old format.

I've split the eng versions into mqtt and templates files to match the new YAML format. This doesn't yet update the README.md or anything to indicate the new format, and I also didn't do the NL version of the file - just posting as far as I got that didn't result in errors from HA.