### PR TITLE
Corrected a missmatch between the verbose environnement flag and read value

### DIFF
--- a/grottconf.py
+++ b/grottconf.py
@@ -425,7 +425,7 @@ class Conf :
     def procenv(self): 
         print("\nGrott process environmental variables")
         if os.getenv('gmode') in ("sniff", "proxy") :  self.mode = self.getenv('gmode')
-        if os.getenv('gverbose') != None :  self.verbose = self.getenv('verbose')
+        if os.getenv('gverbose') != None :  self.verbose = self.getenv('gverbose')
         if os.getenv('gminrecl') != None : 
             if 0 <= int(os.getenv('gminrecl')) <= 255  :     self.minrecl = self.getenv('gminrecl')
         if os.getenv('gdecrypt') != None : self.decrypt = self.getenv('gdecrypt')


### PR DESCRIPTION
When setting the environment flag `gverbose` to True or False, there is no change.

The problem stems from this line:

`if os.getenv('gverbose') != None :  self.verbose = self.getenv('verbose')`

If the env var gverbose is detected, it reads the env var verbose, but verbose is not set, so the verbose mode stays False.

If you set both the env var to :
```
gverbose=True
verbose=True
```

It starts to work

This patch corrects this problem Tested after the patch, you only need to set gverbose for the verbose logging to work.