### PR TITLE
Align library with HA naming conventions

### DIFF
--- a/examples/Home Assistent/grott_ha.py
+++ b/examples/Home Assistent/grott_ha.py
@@ -513,7 +513,6 @@ def make_payload(conf: Conf, device: str, name: str, key: str, unit: str = None)
         "state_topic": f"homeassistant/grott/{device}/state",
         "device": {
             "identifiers": [device],  # Group under a device
-            "name": device,
             "manufacturer": "GrowWatt",
         },
     }


### PR DESCRIPTION
Align library with HA naming conventions, see https://developers.home-assistant.io/docs/core/entity/#entity-naming and change in HA 2023.8 https://github.com/home-assistant/core/pull/95159