### PR TITLE
Align library with HA naming convention

### DIFF
--- a/examples/Home Assistent/grott_ha.py
+++ b/examples/Home Assistent/grott_ha.py
@@ -495,27 +495,19 @@ mapping = {
 def make_payload(conf: Conf, device: str, name: str, key: str, unit: str = None):
     # Default configuration payload
     payload = {
-        "name": "{device} {name}",
+        "name": "{name}",
         "unique_id": f"grott_{device}_{key}",  # Generate a unique device ID
         "state_topic": f"homeassistant/grott/{device}/state",
         "device": {
             "identifiers": [device],  # Group under a device
             "name": device,
-            "manufacturer": "GrowWatt",
+            "manufacturer": "GroWatt",
         },
     }
 
     # If there's a custom mapping add the new values
     if key in mapping:
         payload.update(mapping[key])
-
-    if not payload["name"].startswith("{device} "):
-        # Prepend the {device} template, prevent repeating
-        payload["name"] = "{device} " + payload["name"]
-
-    # Generate the name of the key, with all the param available
-    payload["name"] = payload["name"].format(device=device, name=name, key=key)
-    # HA automatically group the sensor if the device name is prepended
 
     # Reuse the existing divide value if available and not existing
     # and apply it to the HA config


### PR DESCRIPTION
Align library with HA naming conventions, see https://developers.home-assistant.io/docs/core/entity/#entity-naming and change in HA 2023.8 home-assistant/core#95159