### PR TITLE
Update grottserver to be able use registers up to 4096

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ The purpose of Grott is to read, parse and forward the *raw metrics as they are 
 * Added first MIN support (2.8.2)
 
 ### New in Version 2.7  
-* Added first beta of grottserver to act as destination for inverter/datalogger data (remove need to cummunicate with internet).
-  - grottserver version 0.0.5 is able to sent read/write register commands to inverter and datalogger.
-  - see discussions (#98) for more information: https://github.com/johanmeijer/grott/discussions/98
+* Added first beta of **grottserver** to act as destination for inverter/datalogger data (remove need to cummunicate with internet).
+  - - grottserver is able to sent read/write register commands to inverter and datalogger.
+  - see https://github.com/johanmeijer/grott/wiki/Grottserver and discussions https://github.com/johanmeijer/grott/discussions/98 for more information: 
 * Support for SDM630/Raillog connected (see issue #88)
 * Support for SDM630/Inverter (modbus) connected 3 phases support
 * Export to CSV file (see issue #79, pull request #91). 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The purpose of Grott is to read, parse and forward the *raw metrics as they are 
 
 ### New in Version 2.7  
 * Added first beta of **grottserver** to act as destination for inverter/datalogger data (remove need to cummunicate with internet).
-  - - grottserver is able to sent read/write register commands to inverter and datalogger.
+  - grottserver is able to sent read/write register commands to inverter and datalogger.
   - see https://github.com/johanmeijer/grott/wiki/Grottserver and discussions https://github.com/johanmeijer/grott/discussions/98 for more information: 
 * Support for SDM630/Raillog connected (see issue #88)
 * Support for SDM630/Inverter (modbus) connected 3 phases support

--- a/grottserver.py
+++ b/grottserver.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 # grottserver.py emulates the server.growatt.com website and is initial developed for debugging and testing grott.
 # Updated: 2023-01-20
 # Version:
-verrel = "0.0.12"
+verrel = "0.0.12a"
 
 # Declare Variables (to be moved to config file later)
 serverhost = "0.0.0.0"
@@ -348,7 +348,7 @@ class GrottHttpRequestHandler(http.server.BaseHTTPRequestHandler):
 
                 
                 #wait for response
-                for x in range(7):
+                for x in range(15):
                     if verbose: print("\t - Grotthttpserver - wait for GET response")
                     try: 
                         comresp = commandresponse[sendcommand][regkey]


### PR DESCRIPTION
Updated grottserver.py to be able to read registers above 1125 and to write registers above 1024.
Allow both read and write to the registers up to 4096 as Growatt currently use up to register 3374 and will likely go higher in the future.

Fixes #162 
