### PR TITLE
Grottext 2.5.0

### DIFF
--- a/examples/Extensions/grottext.py
+++ b/examples/Extensions/grottext.py
@@ -40,5 +40,3 @@ def grottext(conf,data,jsonmsg) :
 
     #print(r.text)  
     return resultcode
-
-    

--- a/examples/Extensions/grottext.py
+++ b/examples/Extensions/grottext.py
@@ -1,9 +1,9 @@
 def grottext(conf,data,jsonmsg) : 
     ### 
-    ### Example to sent (http put) to a webserver. 
+    ### Example to sent (http post) to a webserver. 
     ### 
-    ### Updated: 2021-01-09
-    ### Version 2.4.0
+    ### Updated: 2023-11-13
+    ### Version 2.5.0
     ###
     ### see: https://www.w3schools.com/python/ref_requests_post.asp  for a clear explonation how to program a http post request: 
     ###
@@ -26,8 +26,12 @@ def grottext(conf,data,jsonmsg) :
     else:
         url = f"http://{conf.extvar['ip']}:{conf.extvar['port']}"
 
+    headers = conf.extvar.get("headers", {})
+    if "Content-Type" not in headers:
+        headers["Content-Type"] = "application/json"
+        
     try: 
-        r = requests.post(url, json = jsonmsg)
+        r = requests.post(url, headers = headers, data = jsonmsg)
 
     except Exception as e: 
         


### PR DESCRIPTION
- The grottext extension now accepts a dictionary of headers in the extvar.
- If Content-Type is not entered, application/json will be set.
- Data is sent on "data" property instead of json, since it is not a json object, but plain text. This change, along with the Content-Type addition makes the server accept is as a Json object