### PR TITLE
Changed default growatt server config

### DIFF
--- a/grottconf.py
+++ b/grottconf.py
@@ -36,7 +36,7 @@ class Conf :
         self.tmzone = "local"                                                                       #set timezone (at this moment only used for influxdb)                
 
         #Growatt server default 
-        self.growattip = "47.91.67.66"
+        self.growattip = "8.209.71.240"
         self.growattport = 5279
 
         #MQTT default


### PR DESCRIPTION
Updated default ip address of the Growatt server to 8.209.71.240. This is required since this morning Growatt changed the server. The old server is now pushing the new ip address to the dataloggers.